### PR TITLE
Fix M-01: KUMABondToken.approve() should revert if the owner of the tokenId is blacklisted

### DIFF
--- a/src/mcag-contracts/KUMABondToken.sol
+++ b/src/mcag-contracts/KUMABondToken.sol
@@ -146,6 +146,7 @@ contract KUMABondToken is ERC721, Pausable, IKUMABondToken {
         whenNotPaused
         notBlacklisted(to)
         notBlacklisted(msg.sender)
+        notBlacklisted(ownerOf(tokenId))
     {
         address owner = ERC721.ownerOf(tokenId);
 

--- a/test/mcag-contracts/KUMABondToken.t.sol
+++ b/test/mcag-contracts/KUMABondToken.t.sol
@@ -210,6 +210,15 @@ contract KUMABondTokenTest is Test {
         _kumaBondToken.approve(_alice, 1);
     }
 
+    function test_approve_RevertWhen_TokenOwnerBlacklistedAndApproveCalledByOperator() external {
+        _kumaBondToken.issueBond(_alice, _bond);
+        vm.prank(_alice);
+        _kumaBondToken.setApprovalForAll(address(this), true);
+        _blacklist.blacklist(_alice);
+        vm.expectRevert(abi.encodeWithSelector(Errors.BLACKLIST_ACCOUNT_IS_BLACKLISTED.selector, _alice));
+        _kumaBondToken.approve(_bob, 1);
+    }
+
     function test_approve_RevertWhen_ApproveToSelf() public {
         _kumaBondToken.issueBond(address(this), _bond);
         vm.expectRevert(abi.encodeWithSelector(Errors.ERC721_APPROVAL_TO_CURRENT_OWNER.selector));


### PR DESCRIPTION
[M-01: KUMABondToken.approve() should revert if the owner of the tokenId is blacklisted](https://github.com/code-423n4/2023-02-kuma-findings/issues/22)