### PR TITLE
Fix M-02: KUMAFeeCollector.changePayees() executes incorrectly when newPayees contains duplicate items

### DIFF
--- a/src/kuma-protocol/KUMAFeeCollector.sol
+++ b/src/kuma-protocol/KUMAFeeCollector.sol
@@ -180,7 +180,9 @@ contract KUMAFeeCollector is IKUMAFeeCollector, UUPSUpgradeable, Initializable {
             }
 
             address payee = newPayees[i];
-            _payees.add(payee);
+            if (!_payees.add(payee)) {
+                revert Errors.PAYEE_ALREADY_EXISTS();
+            }
             _shares[payee] = newShares[i];
             _totalShares += newShares[i];
 

--- a/test/kuma-protocol/KUMAFeeCollector.t.sol
+++ b/test/kuma-protocol/KUMAFeeCollector.t.sol
@@ -313,6 +313,23 @@ contract KUMAFeeCollectorTest is BaseSetUp {
         }
     }
 
+    function test_changePayees_RevertWhen_DuplicatePayees() public {
+        address[] memory newPayees = new address[](4);
+        uint256[] memory newShares = new uint256[](4);
+
+        newPayees[0] = vm.addr(10);
+        newPayees[1] = vm.addr(10);
+        newPayees[2] = vm.addr(11);
+        newPayees[3] = vm.addr(12);
+        newShares[0] = 25;
+        newShares[1] = 25;
+        newShares[2] = 25;
+        newShares[3] = 25;
+
+        vm.expectRevert(Errors.PAYEE_ALREADY_EXISTS.selector);
+        _KUMAFeeCollector.changePayees(newPayees, newShares);
+    }
+
     function test_changePayees_RevertWhen_PayeesAndSharesMistmached() public {
         address[] memory newPayees = new address[](2);
         uint256[] memory newShares = new uint256[](1);


### PR DESCRIPTION
[M-02: KUMAFeeCollector.changePayees() executes incorrectly when newPayees contains duplicate items](https://github.com/code-423n4/2023-02-kuma-findings/issues/13)