### PR TITLE
Fix QA

### DIFF
--- a/src/kuma-protocol/KIBToken.sol
+++ b/src/kuma-protocol/KIBToken.sol
@@ -22,7 +22,6 @@ contract KIBToken is IKIBToken, ERC20PermitUpgradeable, UUPSUpgradeable {
     using Roles for bytes32;
     using WadRayMath for uint256;
 
-    uint256 public constant MAX_YIELD = 1e29;
     uint256 public constant MAX_EPOCH_LENGTH = 365 days;
     uint256 public constant MIN_YIELD = WadRayMath.RAY;
 
@@ -68,6 +67,9 @@ contract KIBToken is IKIBToken, ERC20PermitUpgradeable, UUPSUpgradeable {
         if (epochLength == 0) {
             revert Errors.EPOCH_LENGTH_CANNOT_BE_ZERO();
         }
+        if (epochLength > MAX_EPOCH_LENGTH) {
+            revert Errors.NEW_EPOCH_LENGTH_TOO_HIGH();
+        }
         if (address(KUMAAddressProvider) == address(0)) {
             revert Errors.CANNOT_SET_TO_ADDRESS_ZERO();
         }
@@ -104,7 +106,7 @@ contract KIBToken is IKIBToken, ERC20PermitUpgradeable, UUPSUpgradeable {
         if (epochLength > MAX_EPOCH_LENGTH) {
             revert Errors.NEW_EPOCH_LENGTH_TOO_HIGH();
         }
-        if (epochLength > _epochLength) {
+        if (_getPreviousEpochTimestamp() >= (block.timestamp / epochLength * epochLength)) {
             _refreshCumulativeYield();
             _refreshYield();
         }

--- a/src/kuma-protocol/KUMAFeeCollector.sol
+++ b/src/kuma-protocol/KUMAFeeCollector.sol
@@ -220,7 +220,7 @@ contract KUMAFeeCollector is IKUMAFeeCollector, UUPSUpgradeable, Initializable {
         IERC20 KIBToken = IERC20(_KUMAAddressProvider.getKIBToken(_riskCategory));
         uint256 availableIncome = KIBToken.balanceOf(address(this));
 
-        if (availableIncome > 0) {
+        if (availableIncome > 0 && _payees.length() > 0) {
             _release(KIBToken, availableIncome);
         }
     }

--- a/src/mcag-contracts/Blacklist.sol
+++ b/src/mcag-contracts/Blacklist.sol
@@ -35,6 +35,9 @@ contract Blacklist is IBlacklist {
      * @param account The address to blacklist
      */
     function blacklist(address account) external override onlyBlacklister {
+        if (_blacklisted[account]) {
+            revert Errors.BLACKLIST_ACCOUNT_IS_BLACKLISTED(account);
+        }
         _blacklisted[account] = true;
         emit Blacklisted(account);
     }
@@ -44,6 +47,9 @@ contract Blacklist is IBlacklist {
      * @param account The address to remove from the blacklist
      */
     function unBlacklist(address account) external override onlyBlacklister {
+        if (!_blacklisted[account]) {
+            revert Errors.BLACKLIST_ACCOUNT_IS_NOT_BLACKLISTED(account);
+        }
         _blacklisted[account] = false;
         emit UnBlacklisted(account);
     }

--- a/src/mcag-contracts/KYCToken.sol
+++ b/src/mcag-contracts/KYCToken.sol
@@ -47,6 +47,9 @@ contract KYCToken is ERC721, IKYCToken {
      * @param kycData KYCData struct storing metadata.
      */
     function mint(address to, KYCData calldata kycData) external override onlyRole(Roles.MCAG_MINT_ROLE) {
+        if (to != kycData.owner) {
+            revert Errors.KYC_DATA_OWNER_MISMATCH(to, kycData.owner);
+        }
         _tokenIdCounter.increment();
         uint256 tokenId = _tokenIdCounter.current();
         _kycData[tokenId] = kycData;

--- a/src/mcag-contracts/libraries/Errors.sol
+++ b/src/mcag-contracts/libraries/Errors.sol
@@ -10,7 +10,9 @@ library Errors {
     error ERC721_CALLER_IS_NOT_TOKEN_OWNER();
     error ACCESS_CONTROL_ACCOUNT_IS_MISSING_ROLE(address account, bytes32 role);
     error BLACKLIST_CALLER_IS_NOT_BLACKLISTER();
+    error BLACKLIST_ACCOUNT_IS_NOT_BLACKLISTED(address account);
     error BLACKLIST_ACCOUNT_IS_BLACKLISTED(address account);
     error TRANSMITTED_ANSWER_TOO_HIGH(int256 answer, int256 maxAnswer);
     error TOKEN_IS_NOT_TRANSFERABLE();
+    error KYC_DATA_OWNER_MISMATCH(address to, address owner);
 }

--- a/test/kuma-protocol/KUMAFeeCollector.t.sol
+++ b/test/kuma-protocol/KUMAFeeCollector.t.sol
@@ -105,6 +105,16 @@ contract KUMAFeeCollectorTest is BaseSetUp {
         }
     }
 
+    function test_release_WithNoPayees() external {
+        for (uint256 i; i < 4; i++) {
+            _KUMAFeeCollector.removePayee(_payees[i]);
+        }
+        _KIBToken.mint(address(_KUMAFeeCollector), 4 ether);
+        vm.expectEmit(false, false, false, true);
+        _KUMAFeeCollector.addPayee(_payees[0], 100); // if this line emitts anything other than a PayeeAdded event, test will fail
+        emit PayeeAdded(_payees[0], 100); // Technically the actual event passed into the vm.expectEmit call, since the expected event was emitted in the line above
+    }
+
     function test_release_RevertWhen_NoAvailableIncome() public {
         vm.expectRevert(Errors.NO_AVAILABLE_INCOME.selector);
         _KUMAFeeCollector.release();

--- a/test/kuma-protocol/kib-token/KIBToken.setters.t.sol
+++ b/test/kuma-protocol/kib-token/KIBToken.setters.t.sol
@@ -55,6 +55,21 @@ contract KIBTokenSetters is KIBTokenSetUp {
             )
         );
 
+        vm.expectRevert(Errors.NEW_EPOCH_LENGTH_TOO_HIGH.selector);
+        _deployUUPSProxy(
+            address(newKIBToken),
+            abi.encodeWithSelector(
+                IKIBToken.initialize.selector,
+                _NAME,
+                _SYMBOL,
+                365 days + 1,
+                _KUMAAddressProvider,
+                _CURRENCY,
+                _COUNTRY,
+                _TERM
+            )
+        );
+
         vm.expectRevert(Errors.CANNOT_SET_TO_ADDRESS_ZERO.selector);
         _deployUUPSProxy(
             address(newKIBToken),

--- a/test/mcag-contracts/Blacklist.t.sol
+++ b/test/mcag-contracts/Blacklist.t.sol
@@ -50,6 +50,12 @@ contract BlacklistTest is Test {
         _blacklist.blacklist(address(this));
     }
 
+    function test_blackilst_RevertWhen_AccountIsAlreadyBlacklisted() public {
+        _blacklist.blacklist(_alice);
+        vm.expectRevert(abi.encodeWithSelector(Errors.BLACKLIST_ACCOUNT_IS_BLACKLISTED.selector, _alice));
+        _blacklist.blacklist(_alice);
+    }
+
     function test_unBlacklist() public {
         _blacklist.blacklist(_alice);
         vm.expectEmit(true, false, false, true);
@@ -63,5 +69,10 @@ contract BlacklistTest is Test {
         vm.expectRevert(Errors.BLACKLIST_CALLER_IS_NOT_BLACKLISTER.selector);
         vm.prank(_alice);
         _blacklist.unBlacklist(address(this));
+    }
+
+    function test_unBlacklist_RevertWhen_AccountIsNotBlacklisted() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.BLACKLIST_ACCOUNT_IS_NOT_BLACKLISTED.selector, _alice));
+        _blacklist.unBlacklist(_alice);
     }
 }

--- a/test/mcag-contracts/KYCToken.t.sol
+++ b/test/mcag-contracts/KYCToken.t.sol
@@ -72,6 +72,11 @@ contract KYCTokenTest is Test {
         _kycToken.mint(_alice, _kycData);
     }
 
+    function test_mint_RevertWhen_KycDataOwnerIsNotTheSameAsToAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.KYC_DATA_OWNER_MISMATCH.selector, _alice, address(this)));
+        _kycToken.mint(_alice, _kycData);
+    }
+
     function test_burn() public {
         _kycToken.mint(address(this), _kycData);
         vm.expectEmit(false, false, false, true);


### PR DESCRIPTION
- https://github.com/code-423n4/2023-02-kuma-findings/issues/19
     - [x] [KIB-02L](https://github.com/code-423n4/2023-02-kuma-findings/blob/main/data/0xsomeone-Q.md#kib-02l-insufficient-initial-epoch-sanitization-affected-lines-l68) : recommendation applied
     - [x] [KIB-04L](https://github.com/code-423n4/2023-02-kuma-findings/blob/main/data/0xsomeone-Q.md#kib-04l-inexistent-enforcement-of-minimums--maximums-in-yield-affected-lines-l331) : The `MAX_YIELD` variable was an unused variable (stale logic) and has been removed
     - [x] [KFC-02L](https://github.com/code-423n4/2023-02-kuma-findings/blob/main/data/0xsomeone-Q.md#kfc-02l-improper-release-event-affected-lines-l88-l160) : recommendation applied
     - [x] [KFC-03L](https://github.com/code-423n4/2023-02-kuma-findings/blob/main/data/0xsomeone-Q.md#kfc-03l-inexistent-duplicate-entry-prevention-affected-lines-l175-l180) : recommendation applied

- https://github.com/code-423n4/2023-02-kuma-findings/issues/7
     - [x] [L-05](https://github.com/code-423n4/2023-02-kuma-findings/blob/main/data/bin2chen-Q.md) : recommendation will cause accrued interests loss. Instead a direct check of `previousEpochTimestamp` back shifting was implemented.

- https://github.com/code-423n4/2023-02-kuma-findings/issues/23 : recommendation applied
- https://github.com/code-423n4/2023-02-kuma-findings/issues/15 : recommendation applied